### PR TITLE
Fix constant checking

### DIFF
--- a/src/Payline/PaylineSDK.php
+++ b/src/Payline/PaylineSDK.php
@@ -357,8 +357,8 @@ class PaylineSDK
             $this->webServicesEndpoint = PaylineSDK::INT_ENDPOINT;
             $plnInternal = true;
         }
-        $this->soapclient_options['style'] = defined(SOAP_DOCUMENT) ? SOAP_DOCUMENT : 2;
-        $this->soapclient_options['use'] = defined(SOAP_LITERAL) ? SOAP_LITERAL : 2;
+        $this->soapclient_options['style'] = defined('SOAP_DOCUMENT') ? SOAP_DOCUMENT : 2;
+        $this->soapclient_options['use'] = defined('SOAP_LITERAL') ? SOAP_LITERAL : 2;
         $this->soapclient_options['connection_timeout'] = 5;
         if($plnInternal){
             $this->soapclient_options['stream_context'] = stream_context_create(


### PR DESCRIPTION
defined() function requires string parameter otherwise a notice is thrown if the constant is not defined
