### PR TITLE
Make sure missing optional parameter does not generate an error

### DIFF
--- a/src/Payline/PaylineSDK.php
+++ b/src/Payline/PaylineSDK.php
@@ -1272,8 +1272,10 @@ class PaylineSDK
             'transactionID' => $array['transactionID'],
             'payment' => $this->payment($array['payment']),
             'privateDataList' => $this->privateData,
-            'sequenceNumber' => $array['sequenceNumber']
         );
+        if (isset($array['sequenceNumber'])) {
+            $WSRequest['sequenceNumber'] = $array['sequenceNumber'];
+        }
         return $this->webServiceRequest($array, $WSRequest, PaylineSDK::DIRECT_API, 'doCapture');
     }
 


### PR DESCRIPTION
In a doCapture, the sequence number is optional. This change make sure forgetting sequenceNumber do not generate a PHP error.