### PR TITLE
short array in sample

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
 		}
 	],
 	"require" : {
-		"php" : ">=5.3.0",
+		"php" : ">=5.4.0",
 		"monolog/monolog" : "1.*"
 	},
 	"support" : {


### PR DESCRIPTION
Si on utilise les short array, c'est à dire les crochets, il faut php 5.4 au minimum cf : README.md