### PR TITLE
Add native SoapClient trace ability and allow to override SoapClient

### DIFF
--- a/src/Payline/PaylineSDK.php
+++ b/src/Payline/PaylineSDK.php
@@ -403,6 +403,7 @@ class PaylineSDK
         $this->soapclient_options['use'] = defined('SOAP_LITERAL') ? SOAP_LITERAL : 2;
         $this->soapclient_options['connection_timeout'] = 5;
         $this->soapclient_options['trace'] = false;
+        $this->soapclient_options['soap_client'] = false;
         if($plnInternal){
             $this->soapclient_options['stream_context'] = stream_context_create(
                 array(
@@ -982,7 +983,11 @@ class PaylineSDK
             if(!$this->webServicesEndpoint){
                 throw new \Exception('Endpoint error (check `environment` parameter of PaylineSDK constructor)');
             }
-            $client = new SoapClient(__DIR__ . '/' . self::WSDL, $this->soapclient_options);
+            if ($this->soapclient_options['soap_client'] instanceof \SoapClient)  {
+                $client = $this->soapclient_options['soap_client'];
+            } else {
+                $client = new SoapClient(__DIR__ . '/' . self::WSDL, $this->soapclient_options);
+            }
             $client->__setLocation($this->webServicesEndpoint . $PaylineAPI);
             
             $WSRequest['version'] = isset($array['version']) && strlen($array['version']) ? $array['version'] : '';

--- a/src/Payline/PaylineSDK.php
+++ b/src/Payline/PaylineSDK.php
@@ -1307,8 +1307,10 @@ class PaylineSDK
             $this->logger->addInfo($Method . 'Request', $logRequest);
             $this->logger->addInfo($Method . 'Response', $logResponse);
             if ($this->soapclient_options['trace'] === true) {
-                $this->logger->addDebug($Method . 'Last Request ' . $client->__getLastRequest());
-                $this->logger->addDebug($Method . 'Last Response ' .  $client->__getLastResponse());
+                $this->logger->addDebug($Method . ' Last Request ' . $client->__getLastRequest());
+                $this->logger->addDebug($Method . ' Last Request Headers ' . $client->__getLastRequestHeaders());
+                $this->logger->addDebug($Method . ' Last Response ' .  $client->__getLastResponse());
+                $this->logger->addDebug($Method . ' Last Response Headers ' .  $client->__getLastResponseHeaders());
             }
             return $response;
         } catch (\Exception $e) {

--- a/src/Payline/PaylineSDK.php
+++ b/src/Payline/PaylineSDK.php
@@ -402,6 +402,7 @@ class PaylineSDK
         $this->soapclient_options['style'] = defined('SOAP_DOCUMENT') ? SOAP_DOCUMENT : 2;
         $this->soapclient_options['use'] = defined('SOAP_LITERAL') ? SOAP_LITERAL : 2;
         $this->soapclient_options['connection_timeout'] = 5;
+        $this->soapclient_options['trace'] = false;
         if($plnInternal){
             $this->soapclient_options['stream_context'] = stream_context_create(
                 array(
@@ -1305,6 +1306,10 @@ class PaylineSDK
             $logResponse['result.code'] = $response['result']['code'];
             $this->logger->addInfo($Method . 'Request', $logRequest);
             $this->logger->addInfo($Method . 'Response', $logResponse);
+            if ($this->soapclient_options['trace'] === true) {
+                $this->logger->addDebug($Method . 'Last Request ' . $client->__getLastRequest());
+                $this->logger->addDebug($Method . 'Last Response ' .  $client->__getLastResponse());
+            }
             return $response;
         } catch (\Exception $e) {
             $this->logger->addInfo($Method . 'Request', $logRequest);


### PR DESCRIPTION
Hello, 

With this patch, we are able to log SOAP XML Request and Response. It will help developers to investigate on communication with Payline servers.

How to use it. My Current solution, on actual project, is it extends the PaylineSDK class. Something like that 

And set `trace` option for native PHP SoapClient.

Hope you'll like this feature, and accept it to share and merge it to the Official Payline SDK.

Thanks in advance
Regards
Laurent Laville

```php
use Payline\PaylineSDK as BasePaylineSDK;
use Monolog\Logger;

class PaylineSDK extends BasePaylineSDK
{
    public function __construct(
        string $merchantId,
        string $accessKey,
        array $parameters = [],
        string $proxyHost = '',
        int $proxyPort = null,
        string $proxyLogin = null,
        string $proxyPassword = null,
        Logger $externalLogger = null
    ) {
        $environment = $parameters['environment'];
        $pathLog = '';  // be sure to left content an empty string and not null or filled if we want log sent to a specific logger/format (and not use the default stream H
andler)
        $logLevel = Logger::INFO;

        $logger = $externalLogger;

        $proxyUrl = parse_url($proxyHost);

        if (!empty($proxyUrl['scheme'])) {
            $proxyHost = $proxyUrl['host'];
            $proxyPort = $proxyUrl['port'] ?? 8080;
        }

        parent::__construct($merchantId, $accessKey, $proxyHost, $proxyPort, $proxyLogin, $proxyPassword, $environment, $pathLog, $logLevel, $logger);

        $this->soapclient_options['trace'] = true;
    }

}