### PR TITLE
Allow to customize waiting time when connecting to Payline servers

### DIFF
--- a/src/Payline/PaylineSDK.php
+++ b/src/Payline/PaylineSDK.php
@@ -431,7 +431,7 @@ class PaylineSDK
         }
         $this->soapclient_options['style'] = defined('SOAP_DOCUMENT') ? SOAP_DOCUMENT : 2;
         $this->soapclient_options['use'] = defined('SOAP_LITERAL') ? SOAP_LITERAL : 2;
-        $this->soapclient_options['connection_timeout'] = 5;
+        $this->soapclient_options['connection_timeout'] = defined('SOAP_CONNECTION_TIMEOUT') ? SOAP_CONNECTION_TIMEOUT : 5;
         $this->soapclient_options['trace'] = false;
         $this->soapclient_options['soap_client'] = false;
         if($plnInternal){


### PR DESCRIPTION
Depending on local connection performance, you may need a specific timeout delay.

And as "how long connection timeout should be" can have multiple answers, instead of a fix value, I would like to offer the opportunity to optionnaly adjust it with a new constant.
