### PR TITLE
Support Php 7.4 - Fix PaylineByMonext/payline-php-sdk#62

### DIFF
--- a/src/Payline/PaylineSDK.php
+++ b/src/Payline/PaylineSDK.php
@@ -504,7 +504,7 @@ class PaylineSDK
         $order = new Order();
         if ($array) {
             foreach ($array as $k => $v) {
-                if (array_key_exists($k, $order) && (strlen($v))) {
+                if (property_exists($order, $k) && (strlen($v))) {
                     $order->$k = $v;
                 }
             }
@@ -526,7 +526,7 @@ class PaylineSDK
         $card = new Card();
         if ($array) {
             foreach ($array as $k => $v) {
-                if (array_key_exists($k, $card) && (strlen($v))) {
+                if (property_exists($card, $k) && (strlen($v))) {
                     $card->$k = $v;
                 }
             }
@@ -556,7 +556,7 @@ class PaylineSDK
         $buyer = new Buyer();
         if ($array) {
             foreach ($array as $k => $v) {
-                if (array_key_exists($k, $buyer) && (strlen($v))) {
+                if (property_exists($buyer, $k) && (strlen($v))) {
                     $buyer->$k = $v;
                 }
             }
@@ -607,7 +607,7 @@ class PaylineSDK
             $owner = new Owner();
             if ($array) {
                 foreach ($array as $k => $v) {
-                    if (array_key_exists($k, $owner) && (strlen($v))) {
+                    if (property_exists($owner, $k) && (strlen($v))) {
                         $owner->$k = $v;
                     }
                 }
@@ -671,7 +671,7 @@ class PaylineSDK
         $wallet = new Wallet();
         if ($inWallet) {
             foreach ($inWallet as $k => $v) {
-                if (array_key_exists($k, $wallet) && (strlen($v))) {
+                if (property_exists($wallet, $k) && (strlen($v))) {
                     $wallet->$k = $v;
                 }
             }
@@ -1374,7 +1374,7 @@ class PaylineSDK
         $orderDetail = new OrderDetail();
         if ($newOrderDetail) {
             foreach ($newOrderDetail as $k => $v) {
-                if (array_key_exists($k, $orderDetail) && (strlen($v))) {
+                if (property_exists($orderDetail, $k) && (strlen($v))) {
                     $orderDetail->$k = $v;
                 }
             }
@@ -1394,7 +1394,7 @@ class PaylineSDK
         $private = new PrivateData();
         if ($array) {
             foreach ($array as $k => $v) {
-                if (array_key_exists($k, $private) && (strlen($v))) {
+                if (property_exists($private, $k) && (strlen($v))) {
                     $private->$k = $v;
                 }
             }
@@ -2470,7 +2470,7 @@ class PaylineSDK
     {
         if ($array) {
             foreach ($array as $k => $v) {
-                if (array_key_exists($k, $object) && (strlen($v))) {
+                if (property_exists($object, $k) && (strlen($v))) {
                     $object->$k = $v;
                 }
             }


### PR DESCRIPTION
array_key_exists() on objects is deprecated