### PR TITLE
Fix createWallet

### DIFF
--- a/src/Payline/PaylineSDK.php
+++ b/src/Payline/PaylineSDK.php
@@ -1027,9 +1027,11 @@ class PaylineSDK
                 case 'createWallet':
                     $logRequest = array(
                         'contractNumber' => $array['contractNumber'],
-                        'walletId' => $array['wallet']['walletId'],
-                        'card.number' => $this->hideChars($array['card']['number'], 4, 4)
+                        'walletId' => $array['wallet']['walletId']
                     );
+                    if (!empty($array['card'])) {
+                        $logRequest['card.number'] = $this->hideChars($array['card']['number'], 4, 4);
+                    }
                     $response = self::responseToArray($client->createWallet($WSRequest));
                     break;
                 case 'createWebWallet':

--- a/src/Payline/wsdl/DirectPaymentAPI.wsdl
+++ b/src/Payline/wsdl/DirectPaymentAPI.wsdl
@@ -2152,7 +2152,7 @@
 					<element minOccurs="0" name="firstName" nillable="true" type="xsd:string"/>
 					<element minOccurs="0" name="email" nillable="true" type="xsd:string"/>
 					<element minOccurs="0" name="shippingAddress" nillable="true" type="tns1:address"/>
-					<element name="card" nillable="false" type="tns1:card"/>
+					<element name="card" nillable="true" type="tns1:card"/>
 					<element minOccurs="0" name="comment" nillable="true" type="xsd:string"/>
 					<element minOccurs="0" name="default" nillable="true" type="xsd:string"/>
 					<element minOccurs="0" name="cardStatus" nillable="true" type="xsd:string"/>

--- a/src/Payline/wsdl/ExtendedAPI.wsdl
+++ b/src/Payline/wsdl/ExtendedAPI.wsdl
@@ -2152,7 +2152,7 @@
 					<element minOccurs="0" name="firstName" nillable="true" type="xsd:string"/>
 					<element minOccurs="0" name="email" nillable="true" type="xsd:string"/>
 					<element minOccurs="0" name="shippingAddress" nillable="true" type="tns1:address"/>
-					<element name="card" nillable="false" type="tns1:card"/>
+					<element name="card" nillable="true" type="tns1:card"/>
 					<element minOccurs="0" name="comment" nillable="true" type="xsd:string"/>
 					<element minOccurs="0" name="default" nillable="true" type="xsd:string"/>
 					<element minOccurs="0" name="cardStatus" nillable="true" type="xsd:string"/>

--- a/src/Payline/wsdl/WebPaymentAPI.wsdl
+++ b/src/Payline/wsdl/WebPaymentAPI.wsdl
@@ -2152,7 +2152,7 @@
 					<element minOccurs="0" name="firstName" nillable="true" type="xsd:string"/>
 					<element minOccurs="0" name="email" nillable="true" type="xsd:string"/>
 					<element minOccurs="0" name="shippingAddress" nillable="true" type="tns1:address"/>
-					<element name="card" nillable="false" type="tns1:card"/>
+					<element name="card" nillable="true" type="tns1:card"/>
 					<element minOccurs="0" name="comment" nillable="true" type="xsd:string"/>
 					<element minOccurs="0" name="default" nillable="true" type="xsd:string"/>
 					<element minOccurs="0" name="cardStatus" nillable="true" type="xsd:string"/>


### PR DESCRIPTION
We can create a wallet using either a transactionID
The card was still mandatory even if a transactionID was filled.