### PR TITLE
fix custom SoapClient override option on WebserviceClient

### DIFF
--- a/src/Payline/WebserviceClient.php
+++ b/src/Payline/WebserviceClient.php
@@ -305,7 +305,11 @@ class WebserviceClient
             unset($options['stream_context_to_create']);
         }
 
-        $sdkClient = new SoapClient($this->sdkWsdl, $options);
+        if ($options['soap_client'] instanceof SoapClient)  {
+            $sdkClient = $options['soap_client'];
+        } else {
+            $sdkClient = new SoapClient($this->sdkWsdl, $options);
+        }
         $sdkClient->__setLocation($location);
 
         return $sdkClient;


### PR DESCRIPTION
Hello Monext.

In order to address the issue #84  , here is a quick fix to restore the ability to override the SoapClient, 

Do you have a planned release soon ? 

Regards.