### PR TITLE
Proxy options in getAllFailoverServicesEndpoint()

### DIFF
--- a/src/Payline/WebserviceClient.php
+++ b/src/Payline/WebserviceClient.php
@@ -449,6 +449,11 @@ class WebserviceClient
                                 'method'=>"GET"
                             )
                         );
+                        // Take proxy parameters into account (from soap options in webclient)
+                        if ($this->soapOptions['proxy_host'] != null) {
+                            $opts['http']['proxy'] = $this->soapOptions['proxy_host'].':'.$this->soapOptions['proxy_port'];
+                            $opts['http']['request_fulluri'] = true;
+                        }
                         $context = stream_context_create($opts);
                         $jsonContent = file_get_contents($this->endpointsDirectoryLocation, false, $context);
                         break;


### PR DESCRIPTION
Related issue : #92 

Our servers are using proxy to access internet. During the doWebPayment request, a timeout occurs.

Looking at tcpdump logs we saw the server was requesting the public IP and not passing through the proxy.

We have added some parameters to file_get_contents() to make it works.
